### PR TITLE
Compilation issue with Boost-1.48 (Error in boost lexical_cast)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,10 +27,6 @@ noinst_HEADERS = \
 	boost/archive/portable_binary_iarchive.hpp \
 	boost/integer/cover_operators.hpp \
 	boost/integer/endian.hpp \
-	boost/math/fpclassify.hpp \
-	boost/math/nonfinite_num_facets.hpp \
-	boost/math/signbit.hpp \
-	boost/math/detail/fp_traits.hpp \
 	CompressionType.hpp \
 	CompressedMagic.hpp \
 	FileRememberTimes.hpp \

--- a/src/boost/archive/portable_binary_iarchive.hpp
+++ b/src/boost/archive/portable_binary_iarchive.hpp
@@ -53,7 +53,7 @@
 #endif
 
 #include <boost/integer/endian.hpp>
-#include <boost/math/fpclassify.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/lexical_cast.hpp>
 

--- a/src/boost/archive/portable_binary_oarchive.hpp
+++ b/src/boost/archive/portable_binary_oarchive.hpp
@@ -52,7 +52,7 @@
 #endif
 
 #include <boost/integer/endian.hpp>
-#include <boost/math/fpclassify.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/utility/enable_if.hpp>
 
 #include <boost/type_traits/is_unsigned.hpp>


### PR DESCRIPTION
That patch fixes a compilation issue (https://bugzilla.redhat.com/show_bug.cgi?id=760616) with Boost-1.48.
The compilation error reads "Error in boost lexical_cast". However, it is related to the embedded Boost.Math source code tree.

The patch has been kindly submitted by Petr Machata: https://bugzilla.redhat.com/show_bug.cgi?id=760616#c2

Note that the embedded version of Boost seems outdated. It would be a good idea to see whether more Boost source code could be removed from the local copy, as upstream now certainly implements almost all the missing parts.
