### PR TITLE
Update src/FileHeader.hpp

### DIFF
--- a/src/FileHeader.hpp
+++ b/src/FileHeader.hpp
@@ -93,7 +93,7 @@ public:
 	 */
 	inline bool isValid() const
 	{
-		if ((id_0 != '\037') || (id_1 != '\135') || (id_2 != '\211'))
+		if ((id_0 != (signed char)'\037') || (id_1 != (signed char)'\135') || (id_2 != (signed char)'\211'))
 			return false;
 		return true;
 	}


### PR DESCRIPTION
Fix a reading problem on ARM. It seems '\211' is be treated as unsigned, so ('\211' != (signed char)id_3) is false. It may cause files can't be read through fusecompress.
